### PR TITLE
Update object params values when variables

### DIFF
--- a/leto_schema/lib/src/utilities/ast_from_value.dart
+++ b/leto_schema/lib/src/utilities/ast_from_value.dart
@@ -150,7 +150,7 @@ Object? valueFromAst(
     },
     enum_: (enum_) => EnumValue(enum_.name.value),
     null_: (null_) => null,
-    variable: (variable) => variables?[variable.name],
+    variable: (variable) => variables?[variable.name.value],
   );
 
   if (type != null) {


### PR DESCRIPTION
`variable.name` is a `NamedNode` type, but the `variables` array keys are Strings of the name of the variable.  This causes any variables to not be replaced correctly when they are used in an Object.

Updated to use the value of the NamedNode which can be looked up in the variables Map.